### PR TITLE
provide heap and stack maxes based on what SCD uses

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -149,8 +149,10 @@ global def runFirrtlCompile plan =
       if customTransforms.empty then base
       else "-fct", "{catWith "," customTransforms}", base
 
+    def maxHeap = "4G"
+    def maxStack = "5M"
     def classpath = jars | map getPathName | catWith ":"
-    which "java", "-cp", classpath, main,
+    which "java",  "-Xmx{maxHeap}", "-Xss{maxStack}", "-cp", classpath, main,
     "-tn",            topName,
     "-i",             inputFile.getPathName,
     "-td",            targetDir,


### PR DESCRIPTION
Max Heap: 4G
Max Stack: 5M

These should be exposed to the user at some point, as well as choices like e.g. which JVM to use.