### PR TITLE
Reorder cli add java opts

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -161,10 +161,10 @@ global def runFirrtlCompile plan =
     "--compiler",     compiler.compilerToString,
     Nil
     | withAnnoFiles
+    | withCustomTransforms
+    | withSplitModules
     | withReplSeqMems
     | withInferRW
-    | withSplitModules
-    | withCustomTransforms
 
   def inputs = targetDir.mkdir, inputFile, annoFiles ++ jars ++ visibleFiles
   def filterOutputs all =

--- a/build.wake
+++ b/build.wake
@@ -72,6 +72,9 @@ tuple FirrtlCompilePlan =
   global ReplSeqMem:       List (Pair String String)
   global SplitModules:     Boolean
   global VisibleFiles:     List Path
+  global JavaOpts:         List String
+
+def defaultJavaOpts = "-Xmx4G", "-Xss5M", Nil
 
 global def makeFirrtlCompilePlan jars topName targetDir inputFile =
   FirrtlCompilePlan
@@ -88,6 +91,7 @@ global def makeFirrtlCompilePlan jars topName targetDir inputFile =
   Nil                   # ReplSeqMem
   True                  # SplitModules
   Nil                   # VisibleFiles
+  defaultJavaOpts       # JavaOpts
 
 def logLevelToString ll = match ll
   FirrtlLogError = "error"
@@ -134,6 +138,7 @@ global def runFirrtlCompile plan =
   def replSeqMem       = plan.getFirrtlCompilePlanReplSeqMem
   def splitModules     = plan.getFirrtlCompilePlanSplitModules
   def visibleFiles     = plan.getFirrtlCompilePlanVisibleFiles
+  def javaOpts         = plan.getFirrtlCompilePlanJavaOpts
 
   def main     = "firrtl.Driver"
 
@@ -149,10 +154,8 @@ global def runFirrtlCompile plan =
       if customTransforms.empty then base
       else "-fct", "{catWith "," customTransforms}", base
 
-    def maxHeap = "4G"
-    def maxStack = "5M"
     def classpath = jars | map getPathName | catWith ":"
-    which "java",  "-Xmx{maxHeap}", "-Xss{maxStack}", "-cp", classpath, main,
+    which "java", javaOpts ++ ("-cp", classpath, main,
     "-tn",            topName,
     "-i",             inputFile.getPathName,
     "-td",            targetDir,
@@ -164,7 +167,7 @@ global def runFirrtlCompile plan =
     | withCustomTransforms
     | withSplitModules
     | withReplSeqMems
-    | withInferRW
+    | withInferRW)
 
   def inputs = targetDir.mkdir, inputFile, annoFiles ++ jars ++ visibleFiles
   def filterOutputs all =


### PR DESCRIPTION
Fixes https://github.com/sifive/api-firrtl-sifive/issues/7

Also bring in a change that had been sitting on a branch that re-orders the firrtl command-line invocation to make more sense (people put custom transforms (`-fct`) after the built-ins `repl-seq-mem` and `--infer-rw`).

Rather than just exposing the heap size, I decided to take the approach of letting the user provide java options. It's worth reconsidering the approach of wrapping up the whole java invocation (we'll later want to expose the java executable instead of hardcoding `which "java"`), but this is better at least.

Perhaps instead we should be creating some type like `JavaPlan` which has all of the requisite information in it and we let the user pass it to the `FirrtlCompilePlan`? In any case, this API fixes problems and can remain even if we switch to such an approach.