### PR TITLE
Bump firrtl to 1.2.1

### DIFF
--- a/ivydependencies.json
+++ b/ivydependencies.json
@@ -4,11 +4,11 @@
     "dependencies": [
         "com.typesafe.scala-logging::scala-logging:3.9.0",
         "ch.qos.logback:logback-classic:1.2.3",
-        "com.github.scopt::scopt:3.7.0",
-        "net.jcazevedo::moultingyaml:0.4.0",
-        "org.json4s::json4s-native:3.6.1",
+        "com.github.scopt::scopt:3.7.1",
+        "net.jcazevedo::moultingyaml:0.4.1",
+        "org.json4s::json4s-native:3.6.7",
         "org.antlr:antlr4-runtime:4.7.2",
-        "org.apache.commons:commons-text:1.6",
+        "org.apache.commons:commons-text:1.7",
         "com.google.protobuf:protobuf-java:3.5.0"
       ]
   },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "f738fbe8667ed6b76ec00a15960b9c3a42b8654a",
+        "commit": "f7cf2574889c32ec9db54c4a20cc050a338542b7",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
This bumps the version of FIRRTL pointed to by the head of this repo to 1.2.1. I also updated the ivydependencies, since I noticed that they don't actually match FIRRTL 1.2.0.

Note that I haven't done a full integration test with these changes anywhere yet; I'm just submitting this so that there's a publicly-accessible pointer to this for now.