### PR TITLE
Add Unit argument to make tests lazy.

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -13,4 +13,4 @@ wake --init .
 # such as testing.
 ln -snf "test.wake.template" "$api_firrtl_sifive_path/tests/test.wake"
 
-wake runAPIFIRRTLSiFiveTests
+wake runAPIFIRRTLSiFiveTests Unit

--- a/tests/test.wake.template
+++ b/tests/test.wake.template
@@ -1,4 +1,4 @@
-global def runAPIFIRRTLSiFiveTests =
+global def runAPIFIRRTLSiFiveTests Unit =
   def jars = scalaModuleClasspath firrtlScalaModule
   def topName = 'AndGate'
   def targetDir = "{here}/build"


### PR DESCRIPTION
My bad for not catching this earlier. I noticed it when I blew away my Wake database and saw that even a trivial command was causing the FIRRTL Scala module to be rebuilt.

I'm too used to thinking of Haskell or even Scala def's where functions/callables don't evaluate until you invoke them or need them.