### PR TITLE
Bump to FIRRTL v1.3.0-RC3

### DIFF
--- a/ivydependencies.json
+++ b/ivydependencies.json
@@ -8,8 +8,8 @@
         "net.jcazevedo::moultingyaml:0.4.1",
         "org.json4s::json4s-native:3.6.7",
         "org.antlr:antlr4-runtime:4.7.2",
-        "org.apache.commons:commons-text:1.7",
-        "com.google.protobuf:protobuf-java:3.5.0"
+        "org.apache.commons:commons-text:1.8",
+        "com.google.protobuf:protobuf-java:3.5.1"
       ]
   },
   "antlr": {

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "b68443762a1708492f84edc1901a0750c9f37cc4",
+        "commit": "8f56e69ce2254edfd2f959ad97947b94ab84b8fe",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
Technically bump to merge-base of v1.3.0-RC3 and 1.3.x so to play nice
with Wit dependencies along the stable 1.3.x branch