### PR TITLE
Add 'openjdk/java/1.8.0' resource string to java invocations

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -191,7 +191,7 @@ global def runFirrtlCompile plan =
       else "-fct", "{catWith "," customTransforms}", base
 
     def classpath = jars | map getPathName | catWith ":"
-    which "java", javaOpts ++ ("-cp", classpath, main,
+    "java", javaOpts ++ ("-cp", classpath, main,
     "-tn",            topName,
     "-i",             inputFile.getPathName,
     "-td",            targetDir,
@@ -211,6 +211,7 @@ global def runFirrtlCompile plan =
     filter (!matches `.*\.f` _) all
   def firrtlOutputs =
     makePlan cmdline inputs
+    | setPlanResources ("openjdk/java/1.8.0", Nil)
     | editPlanFnOutputs (_ _ | filterOutputs)
     | runJob
     | getJobOutputs


### PR DESCRIPTION
Add a resource string (via `setPlanResources`) for java invocations.

A wake runner can use this to resolve a shell `PATH` and `JAVA_HOME` to allow setting different installation locations for java.
If no wake runner is available, wake will fallback to the current default `PATH=/usr/bin:/bin`