### PR TITLE
add options for Firrtl Stage

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -92,7 +92,7 @@ tuple FirrtlCompilePlan =
   global SplitModules:     Boolean
   global VisibleFiles:     List Path
   global JavaOpts:         List String
-  global Main:             String
+  global MainClass:        String
   global ExtraArgs:        List String
   # Set this to True if using a Firrtl Stage for Main, ignores removed options TopName and SplitModules
   global UseStage:         Boolean
@@ -124,7 +124,7 @@ global def makeFirrtlCompilePlan jars topName targetDir inputFile =
   True                  # SplitModules
   Nil                   # VisibleFiles
   defaultJavaOpts       # JavaOpts
-  "firrtl.Driver"       # Main
+  "firrtl.Driver"       # MainClass
   Nil                   # ExtraArgs
   False                 # UseStage
 
@@ -193,7 +193,7 @@ global def runFirrtlCompile plan =
   def splitModules     = plan.getFirrtlCompilePlanSplitModules
   def visibleFiles     = plan.getFirrtlCompilePlanVisibleFiles
   def javaOpts         = plan.getFirrtlCompilePlanJavaOpts
-  def main             = plan.getFirrtlCompilePlanMain
+  def main             = plan.getFirrtlCompilePlanMainClass
   def extraArgs        = plan.getFirrtlCompilePlanExtraArgs
   def useStage         = plan.getFirrtlCompilePlanUseStage
 

--- a/build.wake
+++ b/build.wake
@@ -94,7 +94,9 @@ tuple FirrtlCompilePlan =
   global JavaOpts:         List String
   global MainClass:        String
   global ExtraArgs:        List String
-  # Set this to True if using a Firrtl Stage for Main, ignores removed options TopName and SplitModules
+  # Set this to True if using a Firrtl Stage for Main. If True, TopName is
+  # ignored and SplitModules + Compiler are interpreted as
+  # "emit-modules"/"emit-circuit" instead of "split-module"/"compiler"
   global UseStage:         Boolean
 
 def defaultJavaOpts = "-Xmx4G", "-Xss5M", Nil
@@ -204,11 +206,18 @@ global def runFirrtlCompile plan =
         "--repl-seq-mem", "-c:{circuit}:-o:{confFile}", cmdline
       foldr toCmdline base replSeqMem
     def withInferRW base = if inferRW then "--infer-rw", base else base
-    def withSplitModules base = if splitModules && !useStage then "--split-modules", base else base
     def withCustomTransforms base =
       if customTransforms.empty then base
       else "-fct", "{catWith "," customTransforms}", base
     def withTopName base = if !useStage then "-tn", topName, base else base
+
+    def withEmitter base =
+      def compilerName = compiler.compilerToString
+      match splitModules useStage
+        True True = "--emit-modules", compilerName, base
+        False True = "--emit-circuit", compilerName, base
+        True False = "--split-modules", "--compiler", compilerName, base
+        False False = "--compiler", compilerName, base
 
     def classpath = jars | map getPathName | catWith ":"
     "java", javaOpts ++ ("-cp", classpath, main,
@@ -216,14 +225,13 @@ global def runFirrtlCompile plan =
     "-td",            targetDir,
     "-ll",            logLevel.logLevelToString,
     "--info-mode",    infoMode.infoModeToString,
-    "--compiler",     compiler.compilerToString,
     Nil
     | withAnnoFiles
     | withCustomTransforms
-    | withSplitModules
     | withReplSeqMems
     | withInferRW
-    | withTopName)
+    | withTopName
+    | withEmitter)
     ++ extraArgs
 
   def inputs = targetDir.mkdir, inputFile, annoFiles ++ jars ++ visibleFiles

--- a/build.wake
+++ b/build.wake
@@ -92,6 +92,10 @@ tuple FirrtlCompilePlan =
   global SplitModules:     Boolean
   global VisibleFiles:     List Path
   global JavaOpts:         List String
+  global Main:             String
+  global ExtraArgs:        List String
+  # Set this to True if using a Firrtl Stage for Main, ignores removed options TopName and SplitModules
+  global UseStage:         Boolean
 
 def defaultJavaOpts = "-Xmx4G", "-Xss5M", Nil
 
@@ -120,6 +124,9 @@ global def makeFirrtlCompilePlan jars topName targetDir inputFile =
   True                  # SplitModules
   Nil                   # VisibleFiles
   defaultJavaOpts       # JavaOpts
+  "firrtl.Driver"       # Main
+  Nil                   # ExtraArgs
+  False                 # UseStage
 
 def logLevelToString ll = match ll
   FirrtlLogError = "error"
@@ -186,8 +193,9 @@ global def runFirrtlCompile plan =
   def splitModules     = plan.getFirrtlCompilePlanSplitModules
   def visibleFiles     = plan.getFirrtlCompilePlanVisibleFiles
   def javaOpts         = plan.getFirrtlCompilePlanJavaOpts
-
-  def main     = "firrtl.Driver"
+  def main             = plan.getFirrtlCompilePlanMain
+  def extraArgs        = plan.getFirrtlCompilePlanExtraArgs
+  def useStage         = plan.getFirrtlCompilePlanUseStage
 
   def cmdline =
     def withAnnoFiles base = foldr ("-faf", _.getPathName, _) base annoFiles
@@ -196,14 +204,14 @@ global def runFirrtlCompile plan =
         "--repl-seq-mem", "-c:{circuit}:-o:{confFile}", cmdline
       foldr toCmdline base replSeqMem
     def withInferRW base = if inferRW then "--infer-rw", base else base
-    def withSplitModules base = if splitModules then "--split-modules", base else base
+    def withSplitModules base = if splitModules && !useStage then "--split-modules", base else base
     def withCustomTransforms base =
       if customTransforms.empty then base
       else "-fct", "{catWith "," customTransforms}", base
+    def withTopName base = if !useStage then "-tn", topName, base else base
 
     def classpath = jars | map getPathName | catWith ":"
     "java", javaOpts ++ ("-cp", classpath, main,
-    "-tn",            topName,
     "-i",             inputFile.getPathName,
     "-td",            targetDir,
     "-ll",            logLevel.logLevelToString,
@@ -214,7 +222,9 @@ global def runFirrtlCompile plan =
     | withCustomTransforms
     | withSplitModules
     | withReplSeqMems
-    | withInferRW)
+    | withInferRW
+    | withTopName)
+    ++ extraArgs
 
   def inputs = targetDir.mkdir, inputFile, annoFiles ++ jars ++ visibleFiles
   def filterOutputs all =


### PR DESCRIPTION
Since the Firrtl cli is an extendable trait in scala, the current `FirrtlCompilePlan` isn't flexible enough to handle different types of firrtl `Stage`s but still has a lot of fields that are common to all firrtl `Stage`s. This PR makes the main method that `runFirrtlCompile` invokes configurable and adds an `ExtraArgs` field so that `runFirrtlCompile` can be used with `Stage`s that use `FirrtlCLI`. also adds a `UseStage` toggle that turns off the `TopName` and `SplitModule` flags, because these are not supported in the new stage cli.